### PR TITLE
Migrate PyMongo to Motor, model fixes and form creation route

### DIFF
--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -1,7 +1,7 @@
 import typing as t
 
-import pymongo
 import ssl
+from motor.motor_asyncio import AsyncIOMotorClient
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
@@ -11,7 +11,7 @@ from backend.constants import DATABASE_URL, MONGO_DATABASE
 
 class DatabaseMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: t.Callable) -> Response:
-        client = pymongo.MongoClient(
+        client: AsyncIOMotorClient = AsyncIOMotorClient(
             DATABASE_URL,
             ssl_cert_reqs=ssl.CERT_NONE
         )

--- a/backend/models/form.py
+++ b/backend/models/form.py
@@ -13,12 +13,16 @@ class Form(BaseModel):
     features: t.List[str]
     questions: t.List[Question]
 
+    class Config:
+        allow_population_by_field_name = True
+
     @validator("features")
     def validate_features(cls, value: t.List[str]) -> t.Optional[t.List[str]]:
         """Validates is all features in allowed list."""
         # Uppercase everything to avoid mixed case in DB
         value = [v.upper() for v in value]
-        if not all(v in FormFeatures.__members__.values() for v in value):
+        allowed_values = list(v.value for v in FormFeatures.__members__.values())
+        if not all(v in allowed_values for v in value):
             raise ValueError("Form features list contains one or more invalid values.")
 
         if FormFeatures.COLLECT_EMAIL in value and FormFeatures.REQUIRES_LOGIN not in value:  # noqa

--- a/backend/models/form.py
+++ b/backend/models/form.py
@@ -3,7 +3,7 @@ import typing as t
 from pydantic import BaseModel, Field, validator
 
 from backend.constants import FormFeatures
-from backend.models import Question
+from .question import Question
 
 
 class Form(BaseModel):
@@ -14,7 +14,7 @@ class Form(BaseModel):
     questions: t.List[Question]
 
     @validator("features")
-    def validate_features(self, value: t.List[str]) -> t.Optional[t.List[str]]:
+    def validate_features(cls, value: t.List[str]) -> t.Optional[t.List[str]]:
         """Validates is all features in allowed list."""
         # Uppercase everything to avoid mixed case in DB
         value = [v.upper() for v in value]

--- a/backend/models/question.py
+++ b/backend/models/question.py
@@ -36,11 +36,7 @@ class Question(BaseModel):
         """Check does required data exists for question type and remove other data."""
         # When question type don't need data, don't add anything to keep DB clean.
         if value.get("type") not in REQUIRED_QUESTION_TYPE_DATA:
-            return {}
-
-        # Required keys (and values) will be stored to here
-        # to remove all unnecessary stuff
-        result = {}
+            return value
 
         for key, data_type in REQUIRED_QUESTION_TYPE_DATA[value.get("type")].items():
             if key not in value.get("data", {}):
@@ -52,6 +48,4 @@ class Question(BaseModel):
                     f"got {type(value['data'][key]).__name__} instead."
                 )
 
-            result[key] = value["data"][key]
-
-        return result
+        return value

--- a/backend/models/question.py
+++ b/backend/models/question.py
@@ -14,7 +14,7 @@ class Question(BaseModel):
     data: t.Dict[str, t.Any]
 
     @validator("type", pre=True)
-    def validate_question_type(self, value: str) -> t.Optional[str]:
+    def validate_question_type(cls, value: str) -> t.Optional[str]:
         """Checks if question type in currently allowed types list."""
         value = value.lower()
         if value not in QUESTION_TYPES:
@@ -27,19 +27,19 @@ class Question(BaseModel):
 
     @validator("data")
     def validate_question_data(
-            self,
+            cls,
             value: t.Dict[str, t.Any]
     ) -> t.Optional[t.Dict[str, t.Any]]:
         """Check does required data exists for question type and remove other data."""
         # When question type don't need data, don't add anything to keep DB clean.
-        if self.type not in REQUIRED_QUESTION_TYPE_DATA:
+        if cls.type not in REQUIRED_QUESTION_TYPE_DATA:
             return {}
 
         # Required keys (and values) will be stored to here
         # to remove all unnecessary stuff
         result = {}
 
-        for key, data_type in REQUIRED_QUESTION_TYPE_DATA[self.type].items():
+        for key, data_type in REQUIRED_QUESTION_TYPE_DATA[cls.type].items():
             if key not in value:
                 raise ValueError(f"Required question data key '{key}' not provided.")
 

--- a/backend/routes/auth/authorize.py
+++ b/backend/routes/auth/authorize.py
@@ -25,7 +25,7 @@ class AuthorizeRoute(Route):
         bearer_token = await fetch_bearer_token(data["token"])
         user_details = await fetch_user_details(bearer_token["access_token"])
 
-        user_details["admin"] = request.state.db.admins.find_one(
+        user_details["admin"] = await request.state.db.admins.find_one(
             {"_id": user_details["id"]}
         ) is not None
 

--- a/backend/routes/forms/discover.py
+++ b/backend/routes/forms/discover.py
@@ -4,6 +4,7 @@ Return a list of all publicly discoverable forms to unauthenticated users.
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from backend.models import Form
 from backend.route import Route
 
 
@@ -19,8 +20,12 @@ class DiscoverableFormsList(Route):
         forms = []
         cursor = request.state.db.forms.find({"features": "DISCOVERABLE"})
 
+        # Parse it to Form and then back to dictionary
+        # to replace _id with id
         for form in await cursor.to_list(None):
-            forms.append(form)
+            forms.append(Form(**form))
+
+        forms = [form.dict() for form in forms]
 
         return JSONResponse(
             forms

--- a/backend/routes/forms/discover.py
+++ b/backend/routes/forms/discover.py
@@ -17,10 +17,9 @@ class DiscoverableFormsList(Route):
 
     async def get(self, request: Request) -> JSONResponse:
         forms = []
+        cursor = request.state.db.forms.find({"features": "DISCOVERABLE"})
 
-        for form in request.state.db.forms.find({
-            "features": "DISCOVERABLE"
-        }):
+        for form in await cursor.to_list(None):
             forms.append(form)
 
         return JSONResponse(

--- a/backend/routes/forms/index.py
+++ b/backend/routes/forms/index.py
@@ -6,6 +6,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from backend.route import Route
+from backend.models import Form
 
 
 class FormsList(Route):
@@ -22,7 +23,10 @@ class FormsList(Route):
         cursor = request.state.db.forms.find()
 
         for form in await cursor.to_list(None):
-            forms.append(form)
+            forms.append(Form(**form))  # For converting _id to id
+
+        # Covert them back to dictionaries
+        forms = [form.dict() for form in forms]
 
         return JSONResponse(
             forms

--- a/backend/routes/forms/index.py
+++ b/backend/routes/forms/index.py
@@ -1,6 +1,7 @@
 """
 Return a list of all forms to authenticated users.
 """
+from starlette.authentication import requires
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
@@ -15,6 +16,7 @@ class FormsList(Route):
     name = "forms_list"
     path = "/"
 
+    @requires(["authenticated", "admin"])
     async def get(self, request: Request) -> JSONResponse:
         forms = []
         cursor = request.state.db.forms.find()

--- a/backend/routes/forms/index.py
+++ b/backend/routes/forms/index.py
@@ -17,8 +17,9 @@ class FormsList(Route):
 
     async def get(self, request: Request) -> JSONResponse:
         forms = []
+        cursor = request.state.db.forms.find()
 
-        for form in request.state.db.forms.find():
+        for form in await cursor.to_list(None):
             forms.append(form)
 
         return JSONResponse(

--- a/backend/routes/forms/new.py
+++ b/backend/routes/forms/new.py
@@ -1,0 +1,30 @@
+"""
+Creates new form based on data provided.
+"""
+from pydantic import ValidationError
+from starlette.authentication import requires
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from backend.models import Form
+from backend.route import Route
+
+
+class FormCreate(Route):
+    """
+    Creates new form from JSON data.
+    """
+
+    name = "forms_create"
+    path = "/new"
+
+    @requires(["authenticated", "admin"])
+    async def post(self, request: Request) -> JSONResponse:
+        form_data = await request.json()
+        try:
+            form = Form(**form_data)
+        except ValidationError as e:
+            return JSONResponse(e.errors())
+
+        await request.state.db.forms.insert_one(form.dict(by_alias=True))
+        return JSONResponse(form.dict())

--- a/backend/routes/forms/submit.py
+++ b/backend/routes/forms/submit.py
@@ -25,7 +25,7 @@ class SubmitForm(Route):
     async def post(self, request: Request) -> JSONResponse:
         data = await request.json()
 
-        if form := request.state.db.forms.find_one(
+        if form := await request.state.db.forms.find_one(
             {"_id": request.path_params["form_id"], "features": "OPEN"}
         ):
             response_obj = {}

--- a/poetry.lock
+++ b/poetry.lock
@@ -129,6 +129,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "motor"
+version = "2.3.0"
+description = "Non-blocking MongoDB driver for Tornado or asyncio"
+category = "main"
+optional = false
+python-versions = ">=3.5.2"
+
+[package.dependencies]
+pymongo = ">=3.11,<4"
+
+[[package]]
 name = "nested-dict"
 version = "1.61"
 description = "Python dictionary with automatic and arbitrary levels of nestedness"
@@ -146,7 +157,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pydantic"
-version = "1.7.2"
+version = "1.7.3"
 description = "Data validation and settings management using python 3.6 type hinting"
 category = "main"
 optional = false
@@ -297,7 +308,7 @@ python-versions = ">=3.6.1"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "4b12ca2ac95ff86f810d6bd0546b24af82e638f552fa563d7d288fb8284b0872"
+content-hash = "1ed93e3cb2d260977a8ad6a59d71f92e22776cb05bfbc37ed95968ca44e3dc57"
 
 [metadata.files]
 certifi = [
@@ -358,6 +369,10 @@ mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
+motor = [
+    {file = "motor-2.3.0-py3-none-any.whl", hash = "sha256:428d94750123d19fcd0a89b8671ff9b4656f205217bad9f44161748c64c5fc80"},
+    {file = "motor-2.3.0.tar.gz", hash = "sha256:f1692b760d834707e3477996ce8d407af8cd61c1a2abedbf81c22ef14675e61a"},
+]
 nested-dict = [
     {file = "nested_dict-1.61.tar.gz", hash = "sha256:de0fb5bac82ba7bcc23736f09373f18628ea57f92bbaa13480d23f261c41e771"},
 ]
@@ -366,28 +381,28 @@ pycodestyle = [
     {file = "pycodestyle-2.6.0.tar.gz", hash = "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"},
 ]
 pydantic = [
-    {file = "pydantic-1.7.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:dfaa6ed1d509b5aef4142084206584280bb6e9014f01df931ec6febdad5b200a"},
-    {file = "pydantic-1.7.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:2182ba2a9290964b278bcc07a8d24207de709125d520efec9ad6fa6f92ee058d"},
-    {file = "pydantic-1.7.2-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:0fe8b45d31ae53d74a6aa0bf801587bd49970070eac6a6326f9fa2a302703b8a"},
-    {file = "pydantic-1.7.2-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:01f0291f4951580f320f7ae3f2ecaf0044cdebcc9b45c5f882a7e84453362420"},
-    {file = "pydantic-1.7.2-cp36-cp36m-win_amd64.whl", hash = "sha256:4ba6b903e1b7bd3eb5df0e78d7364b7e831ed8b4cd781ebc3c4f1077fbcb72a4"},
-    {file = "pydantic-1.7.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b11fc9530bf0698c8014b2bdb3bbc50243e82a7fa2577c8cfba660bcc819e768"},
-    {file = "pydantic-1.7.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:a3c274c49930dc047a75ecc865e435f3df89715c775db75ddb0186804d9b04d0"},
-    {file = "pydantic-1.7.2-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:c68b5edf4da53c98bb1ccb556ae8f655575cb2e676aef066c12b08c724a3f1a1"},
-    {file = "pydantic-1.7.2-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:95d4410c4e429480c736bba0db6cce5aaa311304aea685ebcf9ee47571bfd7c8"},
-    {file = "pydantic-1.7.2-cp37-cp37m-win_amd64.whl", hash = "sha256:a2fc7bf77ed4a7a961d7684afe177ff59971828141e608f142e4af858e07dddc"},
-    {file = "pydantic-1.7.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b9572c0db13c8658b4a4cb705dcaae6983aeb9842248b36761b3fbc9010b740f"},
-    {file = "pydantic-1.7.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:f83f679e727742b0c465e7ef992d6da4a7e5268b8edd8fdaf5303276374bef52"},
-    {file = "pydantic-1.7.2-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:e5fece30e80087d9b7986104e2ac150647ec1658c4789c89893b03b100ca3164"},
-    {file = "pydantic-1.7.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:ce2d452961352ba229fe1e0b925b41c0c37128f08dddb788d0fd73fd87ea0f66"},
-    {file = "pydantic-1.7.2-cp38-cp38-win_amd64.whl", hash = "sha256:fc21a37ff3f545de80b166e1735c4172b41b017948a3fb2d5e2f03c219eac50a"},
-    {file = "pydantic-1.7.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c9760d1556ec59ff745f88269a8f357e2b7afc75c556b3a87b8dda5bc62da8ba"},
-    {file = "pydantic-1.7.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2c1673633ad1eea78b1c5c420a47cd48717d2ef214c8230d96ca2591e9e00958"},
-    {file = "pydantic-1.7.2-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:388c0c26c574ff49bad7d0fd6ed82fbccd86a0473fa3900397d3354c533d6ebb"},
-    {file = "pydantic-1.7.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:ab1d5e4d8de00575957e1c982b951bffaedd3204ddd24694e3baca3332e53a23"},
-    {file = "pydantic-1.7.2-cp39-cp39-win_amd64.whl", hash = "sha256:f045cf7afb3352a03bc6cb993578a34560ac24c5d004fa33c76efec6ada1361a"},
-    {file = "pydantic-1.7.2-py3-none-any.whl", hash = "sha256:6665f7ab7fbbf4d3c1040925ff4d42d7549a8c15fe041164adfe4fc2134d4cce"},
-    {file = "pydantic-1.7.2.tar.gz", hash = "sha256:c8200aecbd1fb914e1bd061d71a4d1d79ecb553165296af0c14989b89e90d09b"},
+    {file = "pydantic-1.7.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c59ea046aea25be14dc22d69c97bee629e6d48d2b2ecb724d7fe8806bf5f61cd"},
+    {file = "pydantic-1.7.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a4143c8d0c456a093387b96e0f5ee941a950992904d88bc816b4f0e72c9a0009"},
+    {file = "pydantic-1.7.3-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:d8df4b9090b595511906fa48deda47af04e7d092318bfb291f4d45dfb6bb2127"},
+    {file = "pydantic-1.7.3-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:514b473d264671a5c672dfb28bdfe1bf1afd390f6b206aa2ec9fed7fc592c48e"},
+    {file = "pydantic-1.7.3-cp36-cp36m-win_amd64.whl", hash = "sha256:dba5c1f0a3aeea5083e75db9660935da90216f8a81b6d68e67f54e135ed5eb23"},
+    {file = "pydantic-1.7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:59e45f3b694b05a69032a0d603c32d453a23f0de80844fb14d55ab0c6c78ff2f"},
+    {file = "pydantic-1.7.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:5b24e8a572e4b4c18f614004dda8c9f2c07328cb5b6e314d6e1bbd536cb1a6c1"},
+    {file = "pydantic-1.7.3-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:b2b054d095b6431cdda2f852a6d2f0fdec77686b305c57961b4c5dd6d863bf3c"},
+    {file = "pydantic-1.7.3-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:025bf13ce27990acc059d0c5be46f416fc9b293f45363b3d19855165fee1874f"},
+    {file = "pydantic-1.7.3-cp37-cp37m-win_amd64.whl", hash = "sha256:6e3874aa7e8babd37b40c4504e3a94cc2023696ced5a0500949f3347664ff8e2"},
+    {file = "pydantic-1.7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e682f6442ebe4e50cb5e1cfde7dda6766fb586631c3e5569f6aa1951fd1a76ef"},
+    {file = "pydantic-1.7.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:185e18134bec5ef43351149fe34fda4758e53d05bb8ea4d5928f0720997b79ef"},
+    {file = "pydantic-1.7.3-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:f5b06f5099e163295b8ff5b1b71132ecf5866cc6e7f586d78d7d3fd6e8084608"},
+    {file = "pydantic-1.7.3-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:24ca47365be2a5a3cc3f4a26dcc755bcdc9f0036f55dcedbd55663662ba145ec"},
+    {file = "pydantic-1.7.3-cp38-cp38-win_amd64.whl", hash = "sha256:d1fe3f0df8ac0f3a9792666c69a7cd70530f329036426d06b4f899c025aca74e"},
+    {file = "pydantic-1.7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f6864844b039805add62ebe8a8c676286340ba0c6d043ae5dea24114b82a319e"},
+    {file = "pydantic-1.7.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:ecb54491f98544c12c66ff3d15e701612fc388161fd455242447083350904730"},
+    {file = "pydantic-1.7.3-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:ffd180ebd5dd2a9ac0da4e8b995c9c99e7c74c31f985ba090ee01d681b1c4b95"},
+    {file = "pydantic-1.7.3-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:8d72e814c7821125b16f1553124d12faba88e85405b0864328899aceaad7282b"},
+    {file = "pydantic-1.7.3-cp39-cp39-win_amd64.whl", hash = "sha256:475f2fa134cf272d6631072554f845d0630907fce053926ff634cc6bc45bf1af"},
+    {file = "pydantic-1.7.3-py3-none-any.whl", hash = "sha256:38be427ea01a78206bcaf9a56f835784afcba9e5b88fbdce33bbbfbcd7841229"},
+    {file = "pydantic-1.7.3.tar.gz", hash = "sha256:213125b7e9e64713d16d988d10997dabc6a1f73f3991e1ff8e35ebb1409c7dc9"},
 ]
 pyflakes = [
     {file = "pyflakes-2.2.0-py2.py3-none-any.whl", hash = "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.9"
 starlette = "^0.13.8"
 nested_dict = "^1.61"
 uvicorn = {extras = ["standard"], version = "^0.12.2"}
-pymongo = "^3.11.0"
+motor = "^2.3.0"
 python-dotenv = "^0.14.0"
 pyjwt = "^1.7.1"
 httpx = "^0.16.1"


### PR DESCRIPTION
- Migrated PyMongo to asynchronous Motor.
- Made small fixes in models:
    - Removed circular import of Question
    - Use cls instead of self (Pydantic stuff)
    - Fix form features validation (plain `__members__.values()` don't work).
- For listing views, move data to model before returning to:
    - catch broken data
    - return `id` instead `_id`
- Locked all forms listing endpoint only to admins.
- Created endpoint for creating new forms (`/forms/new`, POST).
- Closes #6.