### PR TITLE
Sort routes to have constants first and path fragments last

### DIFF
--- a/backend/route_manager.py
+++ b/backend/route_manager.py
@@ -20,6 +20,9 @@ def construct_route_map_from_dict(route_dict: dict) -> list:
         else:
             route_map.append(Mount(mount, routes=construct_route_map_from_dict(item)))
 
+    # Order non-capturing routes before capturing routes
+    route_map.sort(key=lambda route: "{" in route.path)
+
     return route_map
 
 


### PR DESCRIPTION
This fixes the bug that prevented discoverable from overriding the forms path fragment path.

The issue is specified in [this Notion ticket](https://www.notion.so/pythondiscord/Discoverable-forms-route-does-not-work-91d143070f844376a965856294786f97).

The solution is to sort the route map by whether the URL contains a path fragment (e.g. `/forms/{id:str}`) or not (e.g. `/forms/discoverable`).