### PR TITLE
Provide HTML documentation of endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # IntelliJ project settings
 .idea/
+
+# VSCode Settings
+.vscode/settings.json

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -5,7 +5,8 @@ from starlette.middleware.cors import CORSMiddleware
 
 from backend.authentication import JWTAuthenticationBackend
 from backend.route_manager import create_route_map
-from backend.middleware import DatabaseMiddleware
+from backend.middleware import DatabaseMiddleware, ProtectedDocsMiddleware
+from backend.validation import api
 
 middleware = [
     Middleware(
@@ -19,7 +20,9 @@ middleware = [
         allow_methods=["*"]
     ),
     Middleware(DatabaseMiddleware),
-    Middleware(AuthenticationMiddleware, backend=JWTAuthenticationBackend())
+    Middleware(AuthenticationMiddleware, backend=JWTAuthenticationBackend()),
+    Middleware(ProtectedDocsMiddleware)
 ]
 
 app = Starlette(routes=create_route_map(), middleware=middleware)
+api.register(app)

--- a/backend/constants.py
+++ b/backend/constants.py
@@ -16,6 +16,8 @@ OAUTH2_REDIRECT_URI = os.getenv(
     "https://forms.pythondiscord.com/callback"
 )
 
+DOCS_PASSWORD = os.getenv("DOCS_PASSWORD")
+
 SECRET_KEY = os.getenv("SECRET_KEY", binascii.hexlify(os.urandom(30)).decode())
 
 HCAPTCHA_API_SECRET = os.getenv("HCAPTCHA_API_SECRET")

--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -4,9 +4,9 @@ import ssl
 from motor.motor_asyncio import AsyncIOMotorClient
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response
 
-from backend.constants import DATABASE_URL, MONGO_DATABASE
+from backend.constants import DATABASE_URL, DOCS_PASSWORD, MONGO_DATABASE
 
 
 class DatabaseMiddleware(BaseHTTPMiddleware):
@@ -19,3 +19,13 @@ class DatabaseMiddleware(BaseHTTPMiddleware):
         request.state.db = db
         response = await call_next(request)
         return response
+
+
+class ProtectedDocsMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next: t.Callable) -> Response:
+        if DOCS_PASSWORD and request.url.path.startswith("/docs"):
+            if request.cookies.get("docs_password") != DOCS_PASSWORD:
+                return JSONResponse({"status": "unauthorized"}, status_code=403)
+
+        resp = await call_next(request)
+        return resp

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,7 +1,15 @@
 from .antispam import AntiSpam
 from .discord_user import DiscordUser
-from .form import Form
-from .form_response import FormResponse
+from .form import Form, FormList
+from .form_response import FormResponse, ResponseList
 from .question import Question
 
-__all__ = ["AntiSpam", "DiscordUser", "Form", "FormResponse", "Question"]
+__all__ = [
+    "AntiSpam",
+    "DiscordUser",
+    "Form",
+    "FormResponse",
+    "Question",
+    "FormList",
+    "ResponseList"
+]

--- a/backend/models/form.py
+++ b/backend/models/form.py
@@ -52,3 +52,7 @@ class Form(BaseModel):
             returned_data = data
 
         return returned_data
+
+
+class FormList(BaseModel):
+    __root__: t.List[Form]

--- a/backend/models/form_response.py
+++ b/backend/models/form_response.py
@@ -17,3 +17,7 @@ class FormResponse(BaseModel):
 
     class Config:
         allow_population_by_field_name = True
+
+
+class ResponseList(BaseModel):
+    __root__: t.List[FormResponse]

--- a/backend/routes/auth/authorize.py
+++ b/backend/routes/auth/authorize.py
@@ -2,13 +2,26 @@
 Use a token received from the Discord OAuth2 system to fetch user information.
 """
 
+import httpx
 import jwt
+from pydantic.fields import Field
+from pydantic.main import BaseModel
+from spectree.response import Response
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from backend.constants import SECRET_KEY
 from backend.route import Route
 from backend.discord import fetch_bearer_token, fetch_user_details
+from backend.validation import ErrorMessage, api
+
+
+class AuthorizeRequest(BaseModel):
+    token: str = Field(description="The access token received from Discord.")
+
+
+class AuthorizeResponse(BaseModel):
+    token: str = Field(description="A JWT token containing the user information")
 
 
 class AuthorizeRoute(Route):
@@ -19,11 +32,22 @@ class AuthorizeRoute(Route):
     name = "authorize"
     path = "/authorize"
 
+    @api.validate(
+        json=AuthorizeRequest,
+        resp=Response(HTTP_200=AuthorizeResponse, HTTP_400=ErrorMessage),
+        tags=["auth"]
+    )
     async def post(self, request: Request) -> JSONResponse:
+        """Generate an authorization token."""
         data = await request.json()
 
-        bearer_token = await fetch_bearer_token(data["token"])
-        user_details = await fetch_user_details(bearer_token["access_token"])
+        try:
+            bearer_token = await fetch_bearer_token(data["token"])
+            user_details = await fetch_user_details(bearer_token["access_token"])
+        except httpx.HTTPStatusError:
+            return JSONResponse({
+                "error": "auth_failure"
+            }, status_code=400)
 
         user_details["admin"] = await request.state.db.admins.find_one(
             {"_id": user_details["id"]}

--- a/backend/routes/forms/discover.py
+++ b/backend/routes/forms/discover.py
@@ -1,11 +1,13 @@
 """
 Return a list of all publicly discoverable forms to unauthenticated users.
 """
+from spectree.response import Response
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from backend.models import Form
+from backend.models import Form, FormList
 from backend.route import Route
+from backend.validation import api
 
 
 class DiscoverableFormsList(Route):
@@ -16,7 +18,9 @@ class DiscoverableFormsList(Route):
     name = "discoverable_forms_list"
     path = "/discoverable"
 
+    @api.validate(resp=Response(HTTP_200=FormList), tags=["forms"])
     async def get(self, request: Request) -> JSONResponse:
+        """List all discoverable forms that should be shown on the homepage."""
         forms = []
         cursor = request.state.db.forms.find({"features": "DISCOVERABLE"})
 

--- a/backend/routes/forms/response.py
+++ b/backend/routes/forms/response.py
@@ -1,12 +1,14 @@
 """
 Returns or deletes form response by ID.
 """
+from spectree import Response as RouteResponse
 from starlette.authentication import requires
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from backend.models import FormResponse
 from backend.route import Route
+from backend.validation import ErrorMessage, OkayResponse, api
 
 
 class Response(Route):
@@ -16,8 +18,12 @@ class Response(Route):
     path = "/{form_id:str}/responses/{response_id:str}"
 
     @requires(["authenticated", "admin"])
+    @api.validate(
+        resp=RouteResponse(HTTP_200=FormResponse, HTTP_404=ErrorMessage),
+        tags=["forms", "responses"]
+    )
     async def get(self, request: Request) -> JSONResponse:
-        """Returns single form response by ID."""
+        """Return a single form response by ID."""
         if raw_response := await request.state.db.responses.find_one(
             {
                 "_id": request.path_params["response_id"],
@@ -30,8 +36,12 @@ class Response(Route):
             return JSONResponse({"error": "not_found"}, status_code=404)
 
     @requires(["authenticated", "admin"])
+    @api.validate(
+        resp=RouteResponse(HTTP_200=OkayResponse, HTTP_404=ErrorMessage),
+        tags=["forms", "responses"]
+    )
     async def delete(self, request: Request) -> JSONResponse:
-        """Deletes form response by ID."""
+        """Delete a form response by ID."""
         if not await request.state.db.responses.find_one(
             {
                 "_id": request.path_params["response_id"],

--- a/backend/routes/forms/responses.py
+++ b/backend/routes/forms/responses.py
@@ -1,12 +1,14 @@
 """
 Returns all form responses by form ID.
 """
+from spectree import Response
 from starlette.authentication import requires
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from backend.models import FormResponse
+from backend.models import FormResponse, ResponseList
 from backend.route import Route
+from backend.validation import api, ErrorMessage
 
 
 class Responses(Route):
@@ -18,6 +20,10 @@ class Responses(Route):
     path = "/{form_id:str}/responses"
 
     @requires(["authenticated", "admin"])
+    @api.validate(
+        resp=Response(HTTP_200=ResponseList, HTTP_404=ErrorMessage),
+        tags=["forms", "responses"]
+    )
     async def get(self, request: Request) -> JSONResponse:
         """Returns all form responses by form ID."""
         if not await request.state.db.forms.find_one(

--- a/backend/routes/forms/submit.py
+++ b/backend/routes/forms/submit.py
@@ -4,11 +4,14 @@ Submit a form.
 
 import binascii
 import hashlib
+from typing import Any, Optional
 import uuid
 
 import httpx
+from pydantic.main import BaseModel
 import pydnsbl
 from pydantic import ValidationError
+from spectree import Response
 from starlette.requests import Request
 
 from starlette.responses import JSONResponse
@@ -16,11 +19,22 @@ from starlette.responses import JSONResponse
 from backend.constants import HCAPTCHA_API_SECRET, FormFeatures
 from backend.models import Form, FormResponse
 from backend.route import Route
+from backend.validation import AuthorizationHeaders, ErrorMessage, api
 
 HCAPTCHA_VERIFY_URL = "https://hcaptcha.com/siteverify"
 HCAPTCHA_HEADERS = {
     "Content-Type": "application/x-www-form-urlencoded"
 }
+
+
+class SubmissionResponse(BaseModel):
+    form: Form
+    response: FormResponse
+
+
+class PartialSubmission(BaseModel):
+    response: dict[str, Any]
+    captcha: Optional[str]
 
 
 class SubmitForm(Route):
@@ -31,7 +45,18 @@ class SubmitForm(Route):
     name = "submit_form"
     path = "/submit/{form_id:str}"
 
+    @api.validate(
+        json=PartialSubmission,
+        resp=Response(
+            HTTP_200=SubmissionResponse,
+            HTTP_404=ErrorMessage,
+            HTTP_400=ErrorMessage
+        ),
+        headers=AuthorizationHeaders,
+        tags=["forms", "responses"]
+    )
     async def post(self, request: Request) -> JSONResponse:
+        """Submit a response to the form."""
         data = await request.json()
 
         if form := await request.state.db.forms.find_one(

--- a/backend/routes/index.py
+++ b/backend/routes/index.py
@@ -1,10 +1,24 @@
 """
 Index route for the forms API.
 """
+from pydantic import BaseModel
+from pydantic.fields import Field
+from spectree import Response
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from backend.route import Route
+from backend.validation import api
+
+
+class IndexResponse(BaseModel):
+    message: str = Field(description="A hello message")
+    client: str = Field(
+        description=(
+            "The connecting client, in production this will"
+            " be an IP of our internal load balancer"
+        )
+    )
 
 
 class IndexRoute(Route):
@@ -17,7 +31,11 @@ class IndexRoute(Route):
     name = "index"
     path = "/"
 
+    @api.validate(resp=Response(HTTP_200=IndexResponse))
     def get(self, request: Request) -> JSONResponse:
+        """
+        Return a hello from Python Discord forms!
+        """
         response_data = {
             "message": "Hello, world!",
             "client": request.client.host,

--- a/backend/validation.py
+++ b/backend/validation.py
@@ -1,0 +1,30 @@
+"""Utilities for providing API payload validation."""
+
+from typing import Optional
+from pydantic.fields import Field
+from pydantic.main import BaseModel
+from spectree import SpecTree
+
+api = SpecTree(
+    "starlette",
+    TITLE="Python Discord Forms",
+    PATH="docs"
+)
+
+
+class ErrorMessage(BaseModel):
+    error: str = Field(description="The details on the error")
+
+
+class OkayResponse(BaseModel):
+    status: str = "ok"
+
+
+class AuthorizationHeaders(BaseModel):
+    authorization: Optional[str] = Field(
+        title="Authorization",
+        description=(
+            "The Authorization JWT token received from the "
+            "authorize route in the format `JWT {token}`"
+        )
+    )

--- a/poetry.lock
+++ b/poetry.lock
@@ -280,7 +280,7 @@ version = "5.3.1"
 description = "YAML parser and emitter for Python"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "rfc3986"
@@ -303,6 +303,23 @@ description = "Sniff out which async library your code is running under"
 category = "main"
 optional = false
 python-versions = ">=3.5"
+
+[[package]]
+name = "spectree"
+version = "0.3.16"
+description = "generate OpenAPI document and validate request&response with Python annotations."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pydantic = ">=1.2"
+
+[package.extras]
+dev = ["pytest (>=6)", "flake8 (>=3.8)", "black (>=20.8b1)", "isort (>=5.6)", "autoflake (>=1.4)"]
+falcon = ["falcon"]
+flask = ["flask"]
+starlette = ["starlette"]
 
 [[package]]
 name = "starlette"
@@ -364,7 +381,7 @@ python-versions = ">=3.6.1"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "31df3f6fb5c2739f0ac3158fc73d7ec699bf0b4a228b936e35463f0f977d4beb"
+content-hash = "f0529cd6559892497787a807a6fd3ee7c84b60c04cbc2513bf8caca6b7c3b367"
 
 [metadata.files]
 aiodns = [
@@ -641,6 +658,10 @@ rfc3986 = [
 sniffio = [
     {file = "sniffio-1.2.0-py3-none-any.whl", hash = "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663"},
     {file = "sniffio-1.2.0.tar.gz", hash = "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"},
+]
+spectree = [
+    {file = "spectree-0.3.16-py3-none-any.whl", hash = "sha256:e6cb74ce759361103805dcbd05b311eb46bf11e23486d0787e3f93723d6bab31"},
+    {file = "spectree-0.3.16.tar.gz", hash = "sha256:4d94b79ce2c73acaee5e306c71c7408f5a52e43048e1f7e734a0ce1e75b0c8c8"},
 ]
 starlette = [
     {file = "starlette-0.14.1-py3-none-any.whl", hash = "sha256:d2f55fb835378442b812637ed3e3fcef3d3e22d292fcb8400fa48d2473202411"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ httpx = "^0.16.1"
 gunicorn = "^20.0.4"
 pydantic = "^1.7.2"
 pydnsbl = "^1.1"
+spectree = "^0.3.16"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.8.4"


### PR DESCRIPTION
This PR introduces OpenAPI specification and Pydantic validation generics to allow for better documenting of our endpoints.

In production documentation will be available through https://forms.pythondiscord.com/docs, with a password protected cookie called `docs_password`.