### PR TITLE
Adds Timestamp Field

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -127,13 +127,14 @@ Textareas require no additional configuration.
 
 ## Form response
 
-| Field      | Type                                                 | Description                                                                 |
-| ---------- | ---------------------------------------------------- | --------------------------------------------------------------------------- |
-| `_id`/`id` | MongoDB ObjectID                                     | Random identifier used for the response                                     |
-| `user`     | Optional [user details object](#user-details-object) | An object describing the user that submitted if the form is not anonymous   |
-| `antispam` | Optional [anti spam object](#anti-spam-object)       | An object containing information about the anti-spam on the form submission |
-| `response` | Object                                               | Object containing question IDs mapping to the users answer                  |
-| `form_id`  | String                                               | ID of the form that the user is submitting to                               |
+| Field       | Type                                                 | Description                                                                 |
+| ----------- | ---------------------------------------------------- | --------------------------------------------------------------------------- |
+| `_id`/`id`  | MongoDB ObjectID                                     | Random identifier used for the response                                     |
+| `user`      | Optional [user details object](#user-details-object) | An object describing the user that submitted if the form is not anonymous   |
+| `antispam`  | Optional [anti spam object](#anti-spam-object)       | An object containing information about the anti-spam on the form submission |
+| `response`  | Object                                               | Object containing question IDs mapping to the users answer                  |
+| `form_id`   | String                                               | ID of the form that the user is submitting to                               |
+| `timestamp` | String                                               | ISO formatted string of submission time.                                    |
 
 ### User details object
 

--- a/backend/models/form_response.py
+++ b/backend/models/form_response.py
@@ -18,7 +18,7 @@ class FormResponse(BaseModel):
     timestamp: str
 
     @validator("timestamp", pre=True)
-    def set_timestamp(cls, iso_string: str) -> str:
+    def set_timestamp(cls, iso_string: t.Optional[str]) -> t.Optional[str]:
         if iso_string is None:
             return datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
 

--- a/backend/models/form_response.py
+++ b/backend/models/form_response.py
@@ -1,6 +1,7 @@
+import datetime
 import typing as t
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 
 from .antispam import AntiSpam
 from .discord_user import DiscordUser
@@ -14,6 +15,11 @@ class FormResponse(BaseModel):
     antispam: t.Optional[AntiSpam]
     response: dict[str, t.Any]
     form_id: str
+    timestamp: str = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+
+    @validator("timestamp")
+    def set_timestamp(cls, _: str) -> str:
+        return datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
 
     class Config:
         allow_population_by_field_name = True

--- a/backend/models/form_response.py
+++ b/backend/models/form_response.py
@@ -15,11 +15,18 @@ class FormResponse(BaseModel):
     antispam: t.Optional[AntiSpam]
     response: dict[str, t.Any]
     form_id: str
-    timestamp: str = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+    timestamp: str
 
-    @validator("timestamp")
-    def set_timestamp(cls, _: str) -> str:
-        return datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+    @validator("timestamp", pre=True)
+    def set_timestamp(cls, iso_string: str) -> str:
+        if iso_string is None:
+            return datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+
+        elif not isinstance(iso_string, str):
+            raise ValueError("Submission timestamp must be a string.")
+
+        # Convert to datetime and back to ensure string is valid
+        return datetime.datetime.fromisoformat(iso_string).isoformat()
 
     class Config:
         allow_population_by_field_name = True

--- a/backend/routes/forms/submit.py
+++ b/backend/routes/forms/submit.py
@@ -34,6 +34,8 @@ class SubmitForm(Route):
     async def post(self, request: Request) -> JSONResponse:
         data = await request.json()
 
+        data["timestamp"] = None
+
         if form := await request.state.db.forms.find_one(
             {"_id": request.path_params["form_id"], "features": "OPEN"}
         ):


### PR DESCRIPTION
Closes this [notion ticket](https://www.notion.so/pythondiscord/Add-Timestamp-To-Responses-b99abd810b6d4dd38e3e4e69e935cda9).

Adds timestamp field to user form responses on model generation.

The model saves an ISO formatted time string to avoid serialization errors. The field is set by the program, even if a user passes the timestamp field.