### PR TITLE
`jwt.encode` returns a string, not a bytestring.

### DIFF
--- a/backend/routes/auth/authorize.py
+++ b/backend/routes/auth/authorize.py
@@ -55,6 +55,4 @@ class AuthorizeRoute(Route):
 
         token = jwt.encode(user_details, SECRET_KEY, algorithm="HS256")
 
-        return JSONResponse({
-            "token": token.decode()
-        })
+        return JSONResponse({"token": token})


### PR DESCRIPTION
We updated `pyjwt` to version 2.0.0 in #45.

As of that update, [`jwt.encode` returns a string instead of a bytestring](https://github.com/jpadilla/pyjwt/blob/c96131b970fd341106ce33d0a85b50e3bdbb67ec/CHANGELOG.md#jwtencode-return-type), so `.decode`ing the string for the JSON response returned an error.
