### PR TITLE
Adds A Dev Only Endpoint For Adding Admins

### DIFF
--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -7,12 +7,27 @@ from starlette.authentication import requires
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from backend import constants
 from backend.route import Route
 from backend.validation import ErrorMessage, OkayResponse, api
 
 
 class AdminModel(BaseModel):
     id: str = Field(alias="_id")
+
+
+async def grant(request: Request) -> JSONResponse:
+    """Grant a user administrator privileges."""
+    data = await request.json()
+    admin = AdminModel(**data)
+
+    if await request.state.db.admins.find_one(
+            {"_id": admin.id}
+    ):
+        return JSONResponse({"error": "already_exists"}, status_code=400)
+
+    await request.state.db.admins.insert_one(admin.dict(by_alias=True))
+    return JSONResponse({"status": "ok"})
 
 
 class AdminRoute(Route):
@@ -29,13 +44,25 @@ class AdminRoute(Route):
     )
     async def post(self, request: Request) -> JSONResponse:
         """Grant a user administrator privileges."""
-        data = await request.json()
-        admin = AdminModel(**data)
+        return await grant(request)
 
-        if await request.state.db.admins.find_one(
-            {"_id": admin.id}
-        ):
-            return JSONResponse({"error": "already_exists"}, status_code=400)
 
-        await request.state.db.admins.insert_one(admin.dict(by_alias=True))
-        return JSONResponse({"status": "ok"})
+if not constants.PRODUCTION:
+    class AdminDev(Route):
+        """Adds new admin user with no authentication."""
+
+        name = "admin dev"
+        path = "/admin_dev"
+
+        @api.validate(
+            json=AdminModel,
+            resp=Response(HTTP_200=OkayResponse, HTTP_400=ErrorMessage),
+            tags=["admin"]
+        )
+        async def post(self, request: Request) -> JSONResponse:
+            """
+            A development only endpoint to grant a user administrator privileges.
+
+            Does not require authentication
+            """
+            return await grant(request)


### PR DESCRIPTION
Adds an endpoint if the environment variable `PRODUCTION` is set to false, which reproduces the behavior of the admin endpoint, without authentication. This is meant to make it easier to get an admin account set up in production without having to manually manipulate the database.