### PR TITLE
Empty Authorization Form

### DIFF
--- a/backend/routes/forms/discover.py
+++ b/backend/routes/forms/discover.py
@@ -5,9 +5,32 @@ from spectree.response import Response
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from backend.models import Form, FormList
+from backend import constants
+from backend.models import Form, FormList, Question
 from backend.route import Route
 from backend.validation import api
+
+__FEATURES = [
+    constants.FormFeatures.DISCOVERABLE.value,
+    constants.FormFeatures.OPEN.value,
+    constants.FormFeatures.REQUIRES_LOGIN.value
+]
+
+__QUESTION = Question(
+    id="description",
+    name="Check your cookies after pressing the button.",
+    type="section",
+    data={"text": "You can find cookies under \"Application\" in dev tools."},
+    required=False
+)
+
+EMPTY_FORM = Form(
+    id="empty_auth",
+    features=__FEATURES,
+    questions=[__QUESTION],
+    name="Auth form",
+    description="An empty form to help you get a token."
+)
 
 
 class DiscoverableFormsList(Route):
@@ -31,6 +54,8 @@ class DiscoverableFormsList(Route):
 
         forms = [form.dict(admin=False) for form in forms]
 
-        return JSONResponse(
-            forms
-        )
+        # Return an empty form in development environments to help with authentication.
+        if not forms and not constants.PRODUCTION:
+            forms.append(EMPTY_FORM.dict(admin=False))
+
+        return JSONResponse(forms)

--- a/backend/routes/forms/form.py
+++ b/backend/routes/forms/form.py
@@ -8,8 +8,10 @@ from starlette.authentication import requires
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from backend import constants
 from backend.models import Form
 from backend.route import Route
+from backend.routes.forms.discover import EMPTY_FORM
 from backend.routes.forms.unittesting import filter_unittests
 from backend.validation import ErrorMessage, OkayResponse, api
 
@@ -28,9 +30,10 @@ class SingleForm(Route):
     async def get(self, request: Request) -> JSONResponse:
         """Returns single form information by ID."""
         admin = request.user.admin if request.user.is_authenticated else False
+        form_id = request.path_params["form_id"]
 
         filters = {
-            "_id": request.path_params["form_id"]
+            "_id": form_id
         }
 
         if not admin:
@@ -42,6 +45,10 @@ class SingleForm(Route):
                 form = filter_unittests(form)
 
             return JSONResponse(form.dict(admin=admin))
+
+        elif not constants.PRODUCTION and form_id == EMPTY_FORM.id:
+            # Empty form to help with authentication in development.
+            return JSONResponse(EMPTY_FORM.dict(admin=admin))
 
         return JSONResponse({"error": "not_found"}, status_code=404)
 


### PR DESCRIPTION
The first thing a developer might want to do when setting up the backend is to add a form. Adding a form requires you have your authorization cookie. Getting your authorization cookie requires clicking the discord OAuth button at the bottom of a form. This creates a sort of chicken-or-egg situation.

This PR aims to resolve that by returning a fake form when the backend contains no forms, and the server is running with the `PRODUCTION` flag set to false.

A better alternative would be to have the DB be created with that form, so we don't have to code in a special case for it, but that didn't seem feasible with mongo. There is no equivalent to something like `init.sql` as far as I could tell.