### PR TITLE
Allow Unittest Failures

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -169,9 +169,24 @@ Textareas require no additional configuration.
 | `_id`/`id`  | MongoDB ObjectID                                     | Random identifier used for the response                                     |
 | `user`      | Optional [user details object](#user-details-object) | An object describing the user that submitted if the form is not anonymous   |
 | `antispam`  | Optional [anti spam object](#anti-spam-object)       | An object containing information about the anti-spam on the form submission |
-| `response`  | Object                                               | Object containing question IDs mapping to the users answer                  |
+| `response`  | Object                                               | Object containing question IDs mapping to the users answer*                 |
 | `form_id`   | String                                               | ID of the form that the user is submitting to                               |
 | `timestamp` | String                                               | ISO formatted string of submission time.                                    |
+
+
+&nbsp;* If the question is of type `code`, the response has the following structure:
+```json
+"response": {
+  "<QUESTION ID>": {
+    "value": "<USER CODE>",
+    "passed": bool,
+    "failures": ["<TEST NAME 1>", "<TEST NAME 4>", "<HIDDEN TEST 1>", ...]
+  },
+  ...
+}
+```
+* Values in `<>` are placeholders, while the rest are actual keys
+* `passed` is True only if all tests in the suite passed.
 
 ### User details object
 

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -128,8 +128,13 @@ Textareas require no additional configuration.
     "language": "python",
     // An optinal mapping of unit tests
     "unittests": {
-        "unit_1": "unit_code()",
-        ...
+        // Record a submission, even if the tests don't pass
+        // Default: false
+        "allow_failure": false,
+        "tests": {
+            "unit_1": "unit_code()",
+            ...
+        }
     }
 }
 ```

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -2,13 +2,14 @@ from .antispam import AntiSpam
 from .discord_user import DiscordUser
 from .form import Form, FormList
 from .form_response import FormResponse, ResponseList
-from .question import Question
+from .question import CodeQuestion, Question
 
 __all__ = [
     "AntiSpam",
     "DiscordUser",
     "Form",
     "FormResponse",
+    "CodeQuestion",
     "Question",
     "FormList",
     "ResponseList"

--- a/backend/models/question.py
+++ b/backend/models/question.py
@@ -15,7 +15,7 @@ class Unittests(BaseModel):
     @validator("tests")
     def validate_tests(cls, value: _TESTS_TYPE) -> _TESTS_TYPE:
         """Confirm that at least one test exists in a test suite."""
-        if isinstance(value, dict) and not len(value.keys()):
+        if isinstance(value, dict) and len(value.keys()) == 0:
             raise ValueError("Must have at least one test in a test suite.")
 
         return value

--- a/backend/models/question.py
+++ b/backend/models/question.py
@@ -8,11 +8,13 @@ _TESTS_TYPE = t.Union[t.Dict[str, str], int]
 
 
 class Unittests(BaseModel):
+    """Schema model for unittest suites in code questions."""
     allow_failure: bool = False
     tests: _TESTS_TYPE
 
     @validator("tests")
     def validate_tests(cls, value: _TESTS_TYPE) -> _TESTS_TYPE:
+        """Confirm that at least one test exists in a test suite."""
         if isinstance(value, dict) and not len(value.keys()):
             raise ValueError("Must have at least one test in a test suite.")
 
@@ -20,6 +22,7 @@ class Unittests(BaseModel):
 
 
 class CodeQuestion(BaseModel):
+    """Schema model for questions of type `code`."""
     language: str
     unittests: t.Optional[Unittests]
 

--- a/backend/routes/forms/submit.py
+++ b/backend/routes/forms/submit.py
@@ -195,6 +195,7 @@ class SubmitForm(Route):
                             form.questions[test.question_index].data["unittests"]["allow_failure"]
                         )
 
+                        # An error while communicating with the test runner
                         if test.return_code == 99:
                             failures.append(test)
                             status_code = 500

--- a/backend/routes/forms/submit.py
+++ b/backend/routes/forms/submit.py
@@ -169,7 +169,7 @@ class SubmitForm(Route):
                 unittest_results = await execute_unittest(response_obj, form)
 
                 failures = []
-                status_code = 403
+                status_code = 422
 
                 for test in unittest_results:
                     response_obj.response[test.question_id] = {

--- a/backend/routes/forms/submit.py
+++ b/backend/routes/forms/submit.py
@@ -178,8 +178,15 @@ class SubmitForm(Route):
                     }
 
                     if test.return_code == 0:
-                        test_names = [] if test.passed else test.result.split(";")
-                        response_obj.response[test.question_id]["failures"] = test_names
+                        failure_names = [] if test.passed else test.result.split(";")
+                    elif test.return_code == 5:
+                        failure_names = ["Could not parse user code."]
+                    elif test.return_code == 6:
+                        failure_names = ["Could not load user code."]
+                    else:
+                        failure_names = ["Internal error."]
+
+                    response_obj.response[test.question_id]["failures"] = failure_names
 
                     # Report a failure on internal errors,
                     # or if the test suite doesn't allow failures

--- a/backend/routes/forms/submit.py
+++ b/backend/routes/forms/submit.py
@@ -45,6 +45,18 @@ class PartialSubmission(BaseModel):
     captcha: Optional[str]
 
 
+class UnittestError(BaseModel):
+    question_id: str
+    question_index: int
+    return_code: int
+    passed: bool
+    result: str
+
+
+class UnittestErrorMessage(ErrorMessage):
+    test_results: list[UnittestError]
+
+
 class SubmitForm(Route):
     """
     Submit a form with the provided form ID.
@@ -58,7 +70,8 @@ class SubmitForm(Route):
         resp=Response(
             HTTP_200=SubmissionResponse,
             HTTP_404=ErrorMessage,
-            HTTP_400=ErrorMessage
+            HTTP_400=ErrorMessage,
+            HTTP_422=UnittestErrorMessage
         ),
         tags=["forms", "responses"]
     )

--- a/backend/routes/forms/unittesting.py
+++ b/backend/routes/forms/unittesting.py
@@ -24,7 +24,7 @@ def filter_unittests(form: Form) -> Form:
     """
     for question in form.questions:
         if question.type == "code" and "unittests" in question.data:
-            question.data["unittests"] = len(question.data["unittests"])
+            question.data["unittests"]["tests"] = len(question.data["unittests"]["tests"])
 
     return form
 
@@ -62,7 +62,7 @@ async def execute_unittest(form_response: FormResponse, form: Form) -> list[Unit
     """Execute all the unittests in this form and return the results."""
     unittest_results = []
 
-    for question in form.questions:
+    for index, question in enumerate(form.questions):
         if question.type == "code" and "unittests" in question.data:
             passed = False
 
@@ -70,12 +70,12 @@ async def execute_unittest(form_response: FormResponse, form: Form) -> list[Unit
             hidden_test_counter = count(1)
             hidden_tests = {
                 test.lstrip("#").lstrip("test_"): next(hidden_test_counter)
-                for test in question.data["unittests"].keys()
+                for test in question.data["unittests"]["tests"].keys()
                 if test.startswith("#")
             }
 
             # Compose runner code
-            unit_code = _make_unit_code(question.data["unittests"])
+            unit_code = _make_unit_code(question.data["unittests"]["tests"])
             user_code = _make_user_code(form_response.response[question.id])
 
             code = TEST_TEMPLATE.replace("### USER CODE", user_code)

--- a/backend/routes/forms/unittesting.py
+++ b/backend/routes/forms/unittesting.py
@@ -65,7 +65,19 @@ async def execute_unittest(form_response: FormResponse, form: Form) -> list[Unit
     unittest_results = []
 
     for index, question in enumerate(form.questions):
-        if question.type == "code" and "unittests" in question.data:
+        if question.type == "code":
+
+            # Exit early if the suite doesn't have any tests
+            if question.data["unittests"] is None:
+                unittest_results.append(UnittestResult(
+                    question_id=question.id,
+                    question_index=index,
+                    return_code=0,
+                    passed=True,
+                    result=""
+                ))
+                continue
+
             passed = False
 
             # Tests starting with an hashtag should have censored names.

--- a/backend/routes/forms/unittesting.py
+++ b/backend/routes/forms/unittesting.py
@@ -7,13 +7,15 @@ import httpx
 from httpx import HTTPStatusError
 
 from backend.constants import SNEKBOX_URL
-from backend.models import FormResponse, Form
+from backend.models import Form, FormResponse
 
 with open("resources/unittest_template.py") as file:
     TEST_TEMPLATE = file.read()
 
 
-UnittestResult = namedtuple("UnittestResult", "question_id return_code passed result")
+UnittestResult = namedtuple(
+    "UnittestResult", "question_id question_index return_code passed result"
+)
 
 
 def filter_unittests(form: Form) -> Form:
@@ -119,6 +121,7 @@ async def execute_unittest(form_response: FormResponse, form: Form) -> list[Unit
 
             unittest_results.append(UnittestResult(
                 question_id=question.id,
+                question_index=index,
                 return_code=return_code,
                 passed=passed,
                 result=result

--- a/backend/routes/forms/unittesting.py
+++ b/backend/routes/forms/unittesting.py
@@ -25,7 +25,7 @@ def filter_unittests(form: Form) -> Form:
     This is used to redact the exact tests when sending the form back to the frontend.
     """
     for question in form.questions:
-        if question.type == "code" and "unittests" in question.data:
+        if question.type == "code" and question.data["unittests"] is not None:
             question.data["unittests"]["tests"] = len(question.data["unittests"]["tests"])
 
     return form


### PR DESCRIPTION
Implements this [notion ticket](https://www.notion.so/pythondiscord/Receive-failed-unittest-submissions-60bc34468996414aacde3c29d7090055).

Adds support for an optional `allow_failures` bool. If true, the backend will only return an error (500) if an internal error occurred. If false, the backend will return an error (403 or 500 depending on failure reason).

This PR also adds a model to aid in parsing the new options.