### PR TITLE
Fix IP hash

### DIFF
--- a/backend/routes/forms/submit.py
+++ b/backend/routes/forms/submit.py
@@ -116,7 +116,11 @@ class SubmitForm(Route):
 
             if constants.FormFeatures.DISABLE_ANTISPAM.value not in form.features:
                 ip_hash_ctx = hashlib.md5()
-                ip_hash_ctx.update(request.client.host.encode())
+                ip_hash_ctx.update(
+                    request.headers.get(
+                        "Cf-Connecting-IP", request.client.host
+                    ).encode()
+                )
                 ip_hash = binascii.hexlify(ip_hash_ctx.digest())
                 user_agent_hash_ctx = hashlib.md5()
                 user_agent_hash_ctx.update(request.headers["User-Agent"].encode())


### PR DESCRIPTION
We store IP hash for anti-spam, however we've so far only being hashing the IPs of our NGINX proxy nodes, meaning the data cannot be used to prevent form abuse. This PR corrects that by instead inspecting the Cf-Connecting-IP header and if set hashing that, otherwise falling back to the remote host.