### PR TITLE
Don't include user mention for anonymous form submissions

### DIFF
--- a/backend/routes/forms/submit.py
+++ b/backend/routes/forms/submit.py
@@ -234,11 +234,15 @@ class SubmitForm(Route):
 
             tasks = BackgroundTasks()
             if constants.FormFeatures.WEBHOOK_ENABLED.value in form.features:
+                if constants.FormFeatures.REQUIRES_LOGIN.value in form.features:
+                    request_user = request.user
+                else:
+                    request_user = None
                 tasks.add_task(
                     self.send_submission_webhook,
                     form=form,
                     response=response_obj,
-                    request_user=request.user
+                    request_user=request_user
                 )
 
             if constants.FormFeatures.ASSIGN_ROLE.value in form.features:


### PR DESCRIPTION
We currently use WEBHOOK_ENABLED to determine whether user data should be stored to the db. However, when webhooking a form submission this config is ignored, and the user mention is always included if available.

This means that if a user login in using anohter form, and then submits an anonymous form with the same session, their name will be included in the webhook.