### PR TITLE
Enable Login Form In Production

### DIFF
--- a/backend/routes/forms/discover.py
+++ b/backend/routes/forms/discover.py
@@ -11,25 +11,27 @@ from backend.route import Route
 from backend.validation import api
 
 __FEATURES = [
-    constants.FormFeatures.DISCOVERABLE.value,
     constants.FormFeatures.OPEN.value,
     constants.FormFeatures.REQUIRES_LOGIN.value
 ]
+if not constants.PRODUCTION:
+    __FEATURES.append(constants.FormFeatures.DISCOVERABLE.value)
 
 __QUESTION = Question(
     id="description",
-    name="Check your cookies after pressing the button.",
+    name="Click the button below to log into the forms application.",
     type="section",
-    data={"text": "You can find cookies under \"Application\" in dev tools."},
+    data={"text": ""},
     required=False
 )
 
-EMPTY_FORM = Form(
-    id="empty_auth",
+AUTH_FORM = Form(
+    id="login",
     features=__FEATURES,
     questions=[__QUESTION],
-    name="Auth form",
-    description="An empty form to help you get a token.",
+    name="Login",
+    description="Log into Python Discord Forms.",
+    submitted_text="This page can't be submitted."
 )
 
 
@@ -55,7 +57,7 @@ class DiscoverableFormsList(Route):
         forms = [form.dict(admin=False) for form in forms]
 
         # Return an empty form in development environments to help with authentication.
-        if not forms and not constants.PRODUCTION:
-            forms.append(EMPTY_FORM.dict(admin=False))
+        if not constants.PRODUCTION:
+            forms.append(AUTH_FORM.dict(admin=False))
 
         return JSONResponse(forms)

--- a/backend/routes/forms/form.py
+++ b/backend/routes/forms/form.py
@@ -13,7 +13,7 @@ from starlette.responses import JSONResponse
 from backend import constants, discord
 from backend.models import Form
 from backend.route import Route
-from backend.routes.forms.discover import EMPTY_FORM
+from backend.routes.forms.discover import AUTH_FORM
 from backend.routes.forms.unittesting import filter_unittests
 from backend.validation import ErrorMessage, OkayResponse, api
 
@@ -35,13 +35,14 @@ class SingleForm(Route):
         """Returns single form information by ID."""
         form_id = request.path_params["form_id"].lower()
 
+        if form_id == AUTH_FORM.id:
+            # Empty form for login purposes
+            return JSONResponse(AUTH_FORM.dict(admin=False))
+
         try:
             await discord.verify_edit_access(form_id, request)
             admin = True
         except discord.FormNotFoundError:
-            if not constants.PRODUCTION and form_id == EMPTY_FORM.id:
-                # Empty form to help with authentication in development.
-                return JSONResponse(EMPTY_FORM.dict(admin=False))
             return JSONResponse({"error": "not_found"}, status_code=404)
         except discord.UnauthorizedError:
             admin = False


### PR DESCRIPTION
Adds a non-discoverable login form in all environments to make it easier to authenticate. This was already available in development, but now it'll always be on the homepage too.

Ideally, we'd have an actual login button, but this is an easy solution in the meantime.