### PR TITLE
Fix Poetry 1.2 Support

### DIFF
--- a/.github/workflows/forms-backend.yml
+++ b/.github/workflows/forms-backend.yml
@@ -15,35 +15,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Setup Python
-        id: python
-        uses: actions/setup-python@v2
+      - name: Install Python Dependencies
+        uses: HassanAbouelela/actions/setup-python@setup-python_v1.3.1
         with:
-          python-version: '3.9'
-
-      - name: Setup Poetry
-        uses: snok/install-poetry@v1.1.1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-
-      # When same context exists in cache already, restore this environment.
-      - name: Poetry Environment Caching
-        uses: actions/cache@v2
-        id: python_cache
-        with:
-          path: .venv
-          key: "venv-${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}"
-
-      # Only install dependencies when cache didn't hit.
-      - name: Install dependencies
-        if: steps.python_cache.outputs.cache-hit != 'true'
-        run: |
-          poetry install
+          dev: true
+          python_version: "3.9"
 
       # Use this formatting to show them as GH Actions annotations.
       - name: Run flake8
-        run: "poetry run flake8 --format='::error file=%(path)s,line=%(row)d,col=%(col)d::[flake8] %(code)s: %(text)s'"
+        run: |
+          flake8 --format='::error file=%(path)s,line=%(row)d,col=%(col)d::[flake8] %(code)s: %(text)s'
 
       # Prepare the Pull Request Payload artifact. If this fails, we
       # we fail silently using the `continue-on-error` option. It's

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.9-slim
+FROM --platform=linux/amd64 ghcr.io/chrislovering/python-poetry-base:3.9-slim
 
 # Allow service to handle stops gracefully
 STOPSIGNAL SIGQUIT
@@ -8,19 +8,12 @@ RUN apt-get update && \
     apt-get install -y gcc make && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install Poetry
-RUN pip install poetry
-
-# Copy dependencies-related files
-COPY poetry.lock .
-COPY pyproject.toml .
-
 # Install dependencies
-RUN poetry config virtualenvs.create false
-RUN poetry install --no-dev
+WORKDIR /app
+COPY pyproject.toml poetry.lock ./
+RUN poetry install  --without dev
 
 # Copy all files to container
-WORKDIR /app
 COPY . .
 
 # Set Git SHA build argument
@@ -30,4 +23,5 @@ ARG git_sha="development"
 ENV GIT_SHA=$git_sha
 
 # Start the server with uvicorn
+ENTRYPOINT ["poetry", "run"]
 CMD ["gunicorn", "-w", "2", "-b", "0.0.0.0:8000", "-k", "uvicorn.workers.UvicornWorker", "backend:app"]


### PR DESCRIPTION
Poetry 1.2 introduced a regression which broke pip `--user` installs. These types of install were the main way we did installations in docker and CI, as they made it much more convenient to control the location, availability, and caching of packages.

Poetry's team does not recognize this as a supported use case, so major changes were required to get everything working again. Most of the changes were consolidated into chrislovering/python-poetry-base for docker, and HassanAbouelela/setup-python for CI.

This is part of a larger movement across all python-discord projects.