### PR TITLE
Remove sentry-env

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -21,5 +21,3 @@ spec:
           envFrom:
             - secretRef:
                 name: forms-backend-env
-            - secretRef:
-                name: sentry-env


### PR DESCRIPTION
The sentry dsn is now in forms-backend-env instead