### PR TITLE
Migration to official Sentry release CI action

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -13,12 +13,11 @@ jobs:
         uses: actions/checkout@master
 
       - name: Create a Sentry.io release
-        uses: tclindner/sentry-releases-action@v1.2.0
+        uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: python-discord
           SENTRY_PROJECT: forms-backend
         with:
-          tagName: ${{ github.sha }}
           environment: production
-          releaseNamePrefix: forms-backend@
+          version_prefix: forms-backend@


### PR DESCRIPTION
https://github.com/tclindner/sentry-releases-action no longer works, this PR migrates to the [official sentry release CI action](https://github.com/getsentry/action-release).